### PR TITLE
add windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A lightweight workflow that [optimizes how many actions you can get from a reque
 
 To use this workflow:
 
-1. Put the feedback.sh script into the root directory
+1. Put the `feedback.sh` (or `feedback.ps1` for Windows) script into the root directory
 2. Add the contents of copilot-instructions.md to your agent instructions
 3. (Optional) Add additional instructions for code generation to the bottom of the instructions.
 4. Prompt your AI agent and it will run the script to ask for further instructions after each task

--- a/copilot-instructions.md
+++ b/copilot-instructions.md
@@ -1,5 +1,5 @@
-Always run the feedback.sh script, that is located in the root of the repository, after you finish your instructions or if you need clarification for an instruction. 
-Run the script using: `sh ./feedback.sh`
+Always run the feedback script, that is located in the root of the repository, after you finish your instructions or if you need clarification for an instruction. 
+Run the script using: `sh ./feedback.sh` on Unix or `.\feedback.ps1` on Windows.
 Complete the new instructions given
 Repeat this process until the user tells you to stop.
 

--- a/feedback.ps1
+++ b/feedback.ps1
@@ -1,0 +1,2 @@
+Write-Host -NoNewline "instructions: "
+$instructions = Read-Host


### PR DESCRIPTION
adds a .ps1 script and instructs copilot to use the proper script when on Windows (and also to use .sh when on Unix)

closes #1 